### PR TITLE
Fix difference in TX criteria causing a fork

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,9 +479,9 @@ bool CTransaction::CheckTransaction() const
         const CTxOut& txout = vout[i];
         if (txout.IsEmpty() && !IsCoinBase() && !IsCoinStake())
             return DoS(100, error("CTransaction::CheckTransaction() : txout empty for user transaction"));
-//        // cachecoin: enforce minimum output amount
-//        if ((!txout.IsEmpty()) && txout.nValue < MIN_TXOUT_AMOUNT)
-//            return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue below minimum"));
+        // cachecoin: enforce minimum output amount
+        if ((!txout.IsEmpty()) && txout.nValue < MIN_TXOUT_AMOUNT)
+            return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue below minimum"));
         if (txout.nValue > MAX_MONEY)
             return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue too high"));
         nValueOut += txout.nValue;


### PR DESCRIPTION
This fixes the fork, I suppose the check for min. tx out value needs to be disabled only for block heiht higher than 100K/200K ... I guess you can fix that later when considering the roadmap.
